### PR TITLE
fix router model name in memory graph

### DIFF
--- a/rtx1200/cacti_graph_template_rtx1200_-_memory.xml
+++ b/rtx1200/cacti_graph_template_rtx1200_-_memory.xml
@@ -3,7 +3,7 @@
 		<name>RTX1200 - Memory</name>
 		<graph>
 			<t_title></t_title>
-			<title>IX2105 - Memory</title>
+			<title>RTX1200 - Memory</title>
 			<t_image_format_id></t_image_format_id>
 			<image_format_id>1</image_format_id>
 			<t_height></t_height>


### PR DESCRIPTION
便利に使わせていただいています。ルータのメモリのグラフのタイトルが別の機種だったので修正してみました。
